### PR TITLE
feat: add URL link sharing

### DIFF
--- a/accelonome.js
+++ b/accelonome.js
@@ -35,35 +35,64 @@ function onWebAudioFontLoad() {
     player = new WebAudioFontPlayer(); // https://github.com/surikov/webaudiofont/
 }
 
+/**
+ * @param {unknown} value 
+ * @param {'number'|'boolean'|'string'|'intarray'} as 
+ * @param {unknown} fallback 
+ * @returns 
+ */
+function parse(value, as, fallback) {
+    if (IS_PHONE_APP) {
+        return fallback;
+    }
+    switch (as) {
+        case "number":
+            const parsedNumber = Number(value);
+            return !value || isNaN(parsedNumber) ? fallback : parsedNumber;
+        case "boolean":
+            return value === "true" || value === "on" ? true : fallback;
+        case "string":
+            return value ?? fallback;
+        case "intarray":
+            return value ? value.split(",").map(item => Number(item.trim())) : fallback;
+        default:
+            return fallback;
+    }
+}
+
 const vueApp = {
     data() {
+        const urlParams = IS_PHONE_APP ? {} : Object.fromEntries(new URLSearchParams(window.location.search));
+        const shouldTreatMissingBooleansAsFalse = !!Object.keys(urlParams).length;
         return {
+            // Runtime state
             isPlaying: false,
-            startTempo: 80,
             tempoUI: null,
             tempo: null,
-            endTempo: 160,
-            jumpBpm: 10,
-            tempoChangeAfterX: 4,  // value of the tempo change trigger. could be number of bars, seconds or minutes.
-            noteLength: 0.05,
-            nextNoteTime: 0,
             currentBarUI: 1,
             currentBar: 1,
             scheduledBeats: [],
-            note: 4,  // default to quarter note.
-            beats: 4, // default to 4/4
-            accentedBeats: [1],
-            tempoChangeTrigger: 'bar', // tempo should get changed on Bar by default.
-            lastTempoChangeTime: null, // time when user clicked play.
-            tickSound: "metronome_1",
-            vibrateOn: false,
-            reverseEnabled: false,
+            isPhoneApp: IS_PHONE_APP,
             isReversing: false,
-            shouldAccelerate: true,
-            startCueEnabled: true,
-            drumsEnabled: false,
-            flashOn: false,
-            isPhoneApp: IS_PHONE_APP
+            lastTempoChangeTime: null, // time when user clicked play.
+            // Form input states (serialized in URL for sharing)
+            startTempo: parse(urlParams.startTempo, "number", 80),
+            endTempo: parse(urlParams.endTempo, "number", 160),
+            jumpBpm: parse(urlParams.jumpBpm, "number", 10),
+            tempoChangeAfterX: parse(urlParams.tempoChangeAfterX, "number", 4),  // value of the tempo change trigger. could be number of bars, seconds or minutes.
+            noteLength: parse(urlParams.noteLength, "number", 0.05),
+            nextNoteTime: parse(urlParams.nextNoteTime, "number", 0),
+            note: parse(urlParams.note, "number", 4),  // default to quarter note.
+            beats: parse(urlParams.beats, "number", 4), // default to 4/4
+            accentedBeats: parse(urlParams.accentedBeats, "intarray", [1]),
+            tempoChangeTrigger: parse(urlParams.tempoChangeTrigger, "string", "bar"), // tempo should get changed on Bar by default.
+            tickSound: parse(urlParams.tickSound, "string", "metronome_1"),
+            vibrateOn: parse(urlParams.vibrateOn, "boolean", false),
+            reverseEnabled: parse(urlParams.reverseEnabled, "boolean", false),
+            shouldAccelerate: parse(urlParams.shouldAccelerate, "boolean", shouldTreatMissingBooleansAsFalse ? false : true),
+            startCueEnabled: parse(urlParams.startCueEnabled, "boolean", shouldTreatMissingBooleansAsFalse ? false : true),
+            drumsEnabled: parse(urlParams.drumsEnabled, "boolean", false),
+            flashOn: parse(urlParams.flashOn, "boolean", false),
         }
     },
     methods: {
@@ -87,6 +116,16 @@ const vueApp = {
             this.resetKnobAnimation();
             if (IS_PHONE_APP)
                 this.sendDataToAndroid("stop");
+        },
+        serialize() {
+            // update window url with URLSearchParams based on current form input values
+            const form = this.$refs.form;
+            const formData = new FormData(form);
+            formData.set("accentedBeats", this.accentedBeats);
+            const params = new URLSearchParams(formData);
+            const newUrl = `${window.location.pathname}?${params.toString()}`;
+            // update window history without pushing a new navigation state, so that user can still use back button to exit the page.
+            window.history.replaceState(null, "", newUrl);
         },
         enableStartCue() {
             this.currentBar -= 1;
@@ -313,6 +352,10 @@ const vueApp = {
         //  bootstrap-select doesn't auto update on its own.
         beats: function (newValues, oldValues) {
             this.$nextTick(() => { $('.selectpicker').selectpicker('refresh'); });
+        },
+        // workaround for the fact that boostrap-select is being used for the multiselect, so we can't rely on form serialization
+        accentedBeats: function (newValues, oldValues) {
+            this.serialize();
         },
         startTempo: function (newValues, oldValues) {
             this.tempo = this.startTempo;  // set new tempo only when startTempo's value changes.

--- a/index.html
+++ b/index.html
@@ -37,12 +37,16 @@
 		}
 
 		.knob-container {
+			border-radius: 50%;
+			background: none;
+			border: none;
 			position: relative;
 			width: 320px;
 			height: 320px;
 		}
 
 		.knob-svg {
+			border-radius: inherit;
 			width: 100%;
 			height: 100%;
 		}
@@ -226,7 +230,7 @@
 				<br />
 				<br />
 				<div class="col-xs-12 knob-wrapper">
-					<div class="knob-container" @click="isPlaying ? stop() : play()">
+					<button type="button" class="knob-container" @click="isPlaying ? stop() : play()">
 						<svg class="knob-svg" viewBox="0 0 100 100">
 							<circle class="knob-bg" cx="50" cy="50" r="45"></circle>
 							<circle class="knob-progress" ref="knobProgress" cx="50" cy="50" r="45"></circle>
@@ -239,7 +243,7 @@
 								<br /> <br />Bar: {{currentBarUI}}/{{barsToPlay}}
 							</span>
 						</div>
-					</div>
+					</button>
 				</div>
 
 				<br />

--- a/index.html
+++ b/index.html
@@ -91,160 +91,160 @@
 			<img src="header_icon.png" alt="An image of metronome" width=128 height=128 style="vertical-align:middle" />
 			<span style="vertical-align: middle; font-size: 45px"> Accelonome</span>
 		</header>
-		<form class="form-horizontal col-sm-offset-2 col-sm-10 col-md-offset-1 col-md-5">
-			<div class="form-group">
-				<label for="startTempo" class="col-xs-4 col-md-5 control-label">Starting
-					Tempo
-				</label>
-				<div class="col-xs-8 col-sm-5 col-md-7">
-					<div class="input-group">
-						<input type="number" class="form-control" v-model="startTempo" id="startTempo"
-							:disabled="isPlaying">
-						<div class="input-group-addon">BPM</div>
+		<form ref="form" @input=serialize>
+			<div class="form-horizontal col-sm-offset-2 col-sm-10 col-md-offset-1 col-md-5" >
+				<div class="form-group">
+					<label for="startTempo" class="col-xs-4 col-md-5 control-label">Starting Tempo</label>
+					<div class="col-xs-8 col-sm-5 col-md-7">
+						<div class="input-group">
+							<input type="number" class="form-control" v-model="startTempo" id="startTempo" name="startTempo"
+								:disabled="isPlaying">
+							<div class="input-group-addon">BPM</div>
+						</div>
 					</div>
 				</div>
-			</div>
-			<div class="form-group">
-				<label for="endTempo" class="col-xs-4 col-md-5 control-label">Max Tempo</label>
-				<div class="col-xs-8 col-sm-5 col-md-7">
-					<div class="input-group">
-						<input type="number" class="form-control" v-model="endTempo" id="endTempo"
-							:disabled="!shouldAccelerate">
-						<div class="input-group-addon">BPM</div>
+				<div class="form-group">
+					<label for="endTempo" class="col-xs-4 col-md-5 control-label">Max Tempo</label>
+					<div class="col-xs-8 col-sm-5 col-md-7">
+						<div class="input-group">
+							<input type="number" class="form-control" v-model="endTempo" id="endTempo" name="endTempo"
+								:disabled="!shouldAccelerate">
+							<div class="input-group-addon">BPM</div>
+						</div>
 					</div>
 				</div>
-			</div>
-			<div class="form-group">
-				<label for="jumpTempo" class="col-xs-4 col-md-5 control-label">Increase Tempo
-					By</label>
-				<div class="col-xs-8 col-sm-5 col-md-7">
-					<div class="input-group">
-						<input type="number" class="form-control" v-model="jumpBpm" id="jumpTempo"
+				<div class="form-group">
+					<label for="jumpTempo" class="col-xs-4 col-md-5 control-label">Increase Tempo By</label>
+					<div class="col-xs-8 col-sm-5 col-md-7">
+						<div class="input-group">
+							<input type="number" class="form-control" v-model="jumpBpm" id="jumpTempo" name="jumpTempo"
+								:disabled="isPlaying || !shouldAccelerate">
+							<div class="input-group-addon">BPM</div>
+						</div>
+					</div>
+				</div>
+				<div class="form-group">
+					<label for="tempoChangeAfterX" class="col-xs-4 col-md-5 control-label">After Every</label>
+					<div class="col-xs-3 col-sm-2 col-md-3">
+						<input type="number" class="form-control" v-model="tempoChangeAfterX" id="tempoChangeAfterX" name="tempoChangeAfterX"
 							:disabled="isPlaying || !shouldAccelerate">
-						<div class="input-group-addon">BPM</div>
+					</div>
+					<div class="col-xs-4 col-sm-2 col-md-4" style="text-align: left; padding-left: 0;">
+						<select class="form-control" v-model="tempoChangeTrigger"
+							:disabled="isPlaying || !shouldAccelerate" name="tempoChangeTrigger">
+							<option value="bar">Bars</option>
+							<option value="second">Seconds</option>
+							<option value="minute">Minutes</option>
+						</select>
 					</div>
 				</div>
-			</div>
-			<div class="form-group">
-				<label for="tempoChangeAfterX" class="col-xs-4 col-md-5 control-label">After
-					Every</label>
-				<div class="col-xs-3 col-sm-2 col-md-3">
-					<input type="number" class="form-control" v-model="tempoChangeAfterX" id="tempoChangeAfterX"
-						:disabled="isPlaying || !shouldAccelerate">
-				</div>
-				<div class="col-xs-4 col-sm-2 col-md-4" style="text-align: left; padding-left: 0;">
-					<select class="form-control" v-model="tempoChangeTrigger"
-						:disabled="isPlaying || !shouldAccelerate">
-						<option value="bar">Bars</option>
-						<option value="second">Seconds</option>
-						<option value="minute">Minutes</option>
-					</select>
-				</div>
-			</div>
-			<div class="form-group">
-				<label for="timeSig" class="col-xs-4 col-md-5 control-label">Time
-					Signature</label>
-				<div class="col-xs-3 col-sm-2 col-md-3">
-					<select class="form-control" style="padding-right: 0px;" v-model.number="beats"
-						:disabled="isPlaying" id="timeSig">
-						<option value="1">1</option>
-						<option value="2">2</option>
-						<option value="3">3</option>
-						<option value="4">4</option>
-						<option value="5">5</option>
-						<option value="6">6</option>
-						<option value="7">7</option>
-						<option value="8">8</option>
-						<option value="9">9</option>
-						<option value="10">10</option>
-						<option value="11">11</option>
-						<option value="12">12</option>
-						<option value="13">13</option>
-						<option value="14">14</option>
-						<option value="15">15</option>
-						<option value="16">16</option>
-					</select>
-				</div>
-				<span style="position: relative;float:left;font-size: 25px">/</span>
-				<div class="col-xs-3 col-sm-2 col-md-3">
-					<select class="form-control" style="padding-right: 0px;" v-model="note" :disabled="isPlaying">
-						<option value="2">2</option>
-						<option value="4">4</option>
-						<option value="8">8</option>
-						<option value="16">16</option>
-					</select>
-				</div>
-			</div>
-			<div class="form-group">
-				<div class="col-xs-offset-4 col-xs-4 col-sm-3 col-md-offset-5" style="width:160px">
-					<select class="selectpicker form-control" multiple title="Accent beats"
-						data-selected-text-format="static" mobile=true v-model="accentedBeats">
-						<option v-for="beat in beats" :value=beat :key="beat">{{beat}}</option>
-					</select>
-				</div>
-			</div>
-			<div class="form-group">
-				<label class="col-xs-4 col-md-5 control-label">Sound</label>
-				<div class="col-xs-8 col-md-7">
-					<label class="radio-inline">
-						<input type="radio" v-model="tickSound" value="metronome_1"> 1
-					</label>
-					<label class="radio-inline">
-						<input type="radio" v-model="tickSound" value="metronome_2"> 2
-					</label>
-					<label class="radio-inline">
-						<input type="radio" v-model="tickSound" value="metronome_3"> 3
-					</label>
-					<label class="radio-inline">
-						<input type="radio" v-model="tickSound" value="metronome_4"> 4
-					</label>
-					<label class="checkbox-inline" id="drumsCheckBox">
-						<input type="checkbox" v-model="drumsEnabled" :disabled="!areDrumsAvailable">Drums
-					</label>
-				</div>
-				<div class="col-xs-offset-4 col-xs-8 col-md-offset-5 col-md-8">
-					<label class="checkbox-inline">
-						<input type="checkbox" v-model="vibrateOn"> Vibrate
-					</label>
-					<label class="checkbox-inline">
-						<input type="checkbox" v-model="flashOn" :disabled="!isPhoneApp"> Flash <a v-if="!isPhoneApp"
-							href="https://play.google.com/store/apps/details?id=diy.antweb.accelonome">(app)</a>
-					</label>
-				</div>
-			</div>
-			<br />
-		</form>
-		<div id="playButtons" class="col-md-6">
-			<div class="col-xs-12 col-sm-12 col-md-12">
-				<label class="checkbox-inline"><input v-model="shouldAccelerate" :disabled="isPlaying" type="checkbox">
-					Accelerate</label>
-				<label class="checkbox-inline"><input v-model="startCueEnabled" :disabled="isPlaying" type="checkbox">
-					Count-in</label>
-				<label class="checkbox-inline"><input v-model="reverseEnabled" type="checkbox"> Reverse</label>
-				<button type="button" class="btn btn-danger btn-xs" id="resetButton" @click=reset>Reset
-					tempo</button>
-			</div>
-			<br />
-			<br />
-			<div class="col-xs-12 knob-wrapper">
-				<div class="knob-container" @click="isPlaying ? stop() : play()">
-					<svg class="knob-svg" viewBox="0 0 100 100">
-						<circle class="knob-bg" cx="50" cy="50" r="45"></circle>
-						<circle class="knob-progress" ref="knobProgress" cx="50" cy="50" r="45"></circle>
-					</svg>
-					<div class="knob-text">
-						<span style="font-size: 50px; color: #ffffff;">
-							{{ isPlaying ? tempoUI : 'Start' }}
-						</span>
-						<span v-if="isPlaying && shouldAccelerate" style="font-size: 15px; color: #ffffff;">
-							<br /> <br />Bar: {{currentBarUI}}/{{barsToPlay}}
-						</span>
+				<div class="form-group">
+					<label for="timeSig" class="col-xs-4 col-md-5 control-label">Time Signature</label>
+					<div class="col-xs-3 col-sm-2 col-md-3">
+						<select class="form-control" style="padding-right: 0px;" v-model.number="beats" name="beats"
+							:disabled="isPlaying" id="timeSig">
+							<option value="1">1</option>
+							<option value="2">2</option>
+							<option value="3">3</option>
+							<option value="4">4</option>
+							<option value="5">5</option>
+							<option value="6">6</option>
+							<option value="7">7</option>
+							<option value="8">8</option>
+							<option value="9">9</option>
+							<option value="10">10</option>
+							<option value="11">11</option>
+							<option value="12">12</option>
+							<option value="13">13</option>
+							<option value="14">14</option>
+							<option value="15">15</option>
+							<option value="16">16</option>
+						</select>
+					</div>
+					<span style="position: relative;float:left;font-size: 25px">/</span>
+					<div class="col-xs-3 col-sm-2 col-md-3">
+						<select class="form-control" style="padding-right: 0px;" v-model="note" :disabled="isPlaying" name="note">
+							<option value="2">2</option>
+							<option value="4">4</option>
+							<option value="8">8</option>
+							<option value="16">16</option>
+						</select>
 					</div>
 				</div>
+				<div class="form-group">
+					<div class="col-xs-offset-4 col-xs-4 col-sm-3 col-md-offset-5" style="width:160px">
+						<select class="selectpicker form-control" multiple title="Accent beats"
+							data-selected-text-format="static" mobile=true v-model="accentedBeats">
+							<option v-for="beat in beats" :value=beat :key="beat">{{beat}}</option>
+						</select>
+					</div>
+				</div>
+				<div class="form-group">
+					<label class="col-xs-4 col-md-5 control-label">Sound</label>
+					<div class="col-xs-8 col-md-7">
+						<label class="radio-inline">
+							<input type="radio" name="tickSound" v-model="tickSound" value="metronome_1"> 1
+						</label>
+						<label class="radio-inline">
+							<input type="radio" name="tickSound" v-model="tickSound" value="metronome_2"> 2
+						</label>
+						<label class="radio-inline">
+							<input type="radio" name="tickSound" v-model="tickSound" value="metronome_3"> 3
+						</label>
+						<label class="radio-inline">
+							<input type="radio" name="tickSound" v-model="tickSound" value="metronome_4"> 4
+						</label>
+						<label class="checkbox-inline" id="drumsCheckBox">
+							<input type="checkbox" v-model="drumsEnabled" :disabled="!areDrumsAvailable" name="drumsEnabled">Drums
+						</label>
+					</div>
+					<div class="col-xs-offset-4 col-xs-8 col-md-offset-5 col-md-8">
+						<label class="checkbox-inline">
+							<input type="checkbox" v-model="vibrateOn" name="vibrateOn"> Vibrate
+						</label>
+						<label class="checkbox-inline">
+							<input type="checkbox" v-model="flashOn" :disabled="!isPhoneApp" name="flashOn"> Flash <a v-if="!isPhoneApp"
+								href="https://play.google.com/store/apps/details?id=diy.antweb.accelonome">(app)</a>
+						</label>
+					</div>
+				</div>
+				<br />
 			</div>
+			<div id="playButtons" class="col-md-6">
+				<div class="col-xs-12 col-sm-12 col-md-12">
+					<label class="checkbox-inline">
+						<input v-model="shouldAccelerate" :disabled="isPlaying" type="checkbox" name="shouldAccelerate">
+						Accelerate
+					</label>
+					<label class="checkbox-inline">
+						<input v-model="startCueEnabled" :disabled="isPlaying" type="checkbox" name="startCueEnabled">
+						Count-in
+					</label>
+					<label class="checkbox-inline"><input v-model="reverseEnabled" type="checkbox" name="reverseEnabled"> Reverse</label>
+					<button type="button" class="btn btn-danger btn-xs" id="resetButton" @click=reset>Reset tempo</button>
+				</div>
+				<br />
+				<br />
+				<div class="col-xs-12 knob-wrapper">
+					<div class="knob-container" @click="isPlaying ? stop() : play()">
+						<svg class="knob-svg" viewBox="0 0 100 100">
+							<circle class="knob-bg" cx="50" cy="50" r="45"></circle>
+							<circle class="knob-progress" ref="knobProgress" cx="50" cy="50" r="45"></circle>
+						</svg>
+						<div class="knob-text">
+							<span style="font-size: 50px; color: #ffffff;">
+								{{ isPlaying ? tempoUI : 'Start' }}
+							</span>
+							<span v-if="isPlaying && shouldAccelerate" style="font-size: 15px; color: #ffffff;">
+								<br /> <br />Bar: {{currentBarUI}}/{{barsToPlay}}
+							</span>
+						</div>
+					</div>
+				</div>
 
-			<br />
-		</div>
+				<br />
+			</div>
+		</form>
 		<footer class="col-xs-12 col-sm-12 col-md-12 text-center">
 			<br />
 			<h5>If you liked this, consider


### PR DESCRIPTION
Tested with `npx live-server .` in lieu of vite or another local dev server (might be a nice enhancement to add for future devs, and to reduce reliance on CDNs).

- Made the `<form>` wrap all inputs and gave each input a `name` attribute (helps with auto-serializing)
- Added an `input` listener to the form that calls a `serialize` method to construct `URLSearchParams` and update the URL
  - Had to watch the `accentedBeats` property separately since you're using Bootstrap for multi-select.

Not sure if any of this breaks the mobile app; are you building that with the code in this repo? I saw an `IS_PHONE_APP` variable and wasn't sure.